### PR TITLE
Fix(sdist): Fix full path to the ini

### DIFF
--- a/src/main/MANIFEST.in
+++ b/src/main/MANIFEST.in
@@ -1,1 +1,1 @@
-include .ini
+include ilikeapples/pink_lady/file.ini


### PR DESCRIPTION
Fix number one. Works only with `python setup.py sdist` but not with `bdist_wheel`.