### PR TITLE
Fix(sdist+bdist): Fix full path to the ini, include package data

### DIFF
--- a/src/main/MANIFEST.in
+++ b/src/main/MANIFEST.in
@@ -1,1 +1,1 @@
-include .ini
+include ilikeapples/pink_lady/file.ini

--- a/src/main/setup.py
+++ b/src/main/setup.py
@@ -11,5 +11,6 @@ setup(
         'ibis-framework[impala]==2.0.0',
         'numpy==1.21.4',
         'pandas==1.3.4'
-    ]
+    ],
+    include_package_data=True,
 )


### PR DESCRIPTION
Fix both sdist and bdist_wheel. Works for me with Python 2.7 and 3.7.